### PR TITLE
원활한 배포를 위한 스크립트 추가

### DIFF
--- a/.gitignore-release
+++ b/.gitignore-release
@@ -1,0 +1,60 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+Pods/
+
+# Android/IJ
+#
+.idea
+*.iml
+.gradle
+local.properties
+lib/android/src/main/gen
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+package-lock.json
+
+# Rubygem bundles
+#
+bundles/
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+android/gradle
+android/gradlew
+android/gradlew.bat
+
+.classpath
+.project
+.settings/
+msbuild.binlog
+example/msbuild.binlog

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "yarn tsc --noEmit && yarn eslint ./src --ext .ts,.tsx",
     "build": "yarn tsc",
     "prepare": "yarn build",
+    "release": "./scripts/release.sh",
     "appium": "appium",
     "test:windows": "yarn jest --setupFiles=./jest-setups/jest.setup.windows.js"
   },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# 1. Update package.json version
+# 2. yarn release v1.0.0
+
+# Script usage: ./relesase.sh VERSION_TAG
+# eg. ./release.sh v11.0.2-ct.2
+
+branch="classting"
+version=$1
+
+if [ -z "$version" ]
+then
+  echo "E: version tag is required"
+  exit -1
+fi
+
+echo -n "Do you want release as '$version'? (Y/n): "
+read answer
+
+if [ "$answer" != "${answer#[Nn]}" ];
+then
+  exit 0
+else
+  echo "(1/3) Clean & install dependencies"
+  rm -rf lib
+  rm -rf node_modules && yarn
+  mv .gitignore-release .gitignore
+
+  echo "(2/3) Build typescript"
+  yarn build
+
+  echo "(3/3) Create release commit with tag"
+  release_branch="release/$version"
+  git checkout -b $release_branch
+  git add .
+  git commit -m "release: bump up version to $version"
+  git tag $version
+  git push origin $release_branch
+  git push origin $version
+fi


### PR DESCRIPTION
## Description

수동으로 빌드하고 관리해야하는 번거로움을 최소화하기 위해
헬퍼 스크립트를 작성하여 추가함

- npm 에서 다운받아 사용할 때에는 빌드되어있는 js 를 내려받기 때문에 문제가 없으나, fork 한 레포에서 코드를 받아 사용하기 위해선 수동 빌드가 필요합니다 (TS)
- 이에 따라 TS 빌드/커밋/버전 태그를 자동으로 생성하여 push 해주는 스크립트를 추가했습니다.

> 스크립트 사용법은 wiki 에 남겨두도록 하겠습니다.

### How to test

- 임의의 버전 배포 테스트
  - yarn release v0.0.1-test.1
  - 스크립트 종료 후 본 저장소에  v0.0.1-test.1 태그가 생성되어있어야 함
  - (확인 후 테스트로 추가했던 태그와 브랜치 제거)
    ```
    git push --delete v0.0.1-test.1
    git push --delete release/v0.0.1-test.1
    ``` 


### Screenshots

(배포 커밋 변경사항)
![image](https://user-images.githubusercontent.com/26512984/145154372-edacdf4c-af04-4d85-b33c-85b761a67dc4.png)

(push 된 브랜치/태그)
![image](https://user-images.githubusercontent.com/26512984/145154518-93b2da7f-c967-4e3a-aacd-1c76620db4aa.png)

