### PR TITLE
링크 클릭 시 다운로드 시도인지 식별하여 onLoadStart 호출 여부결정

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -971,6 +971,9 @@ static NSDictionary* customCertificatesForHost;
   NSURLRequest *request = navigationAction.request;
   BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
 
+  NSArray *allowFileExtensions = @[@"doc",@"hwp",@"xls",@"ppt",@"docx",@"xlsx",@"pptx",@"pdf",@"zip",@"jpeg",@"jpg",@"png",@"gif",@"mp3",@"mp4",@"avi",@"mov"];
+  NSString *fileExtension = request.URL.absoluteString.pathExtension;
+  BOOL isDownload = [allowFileExtensions containsObject:[fileExtension lowercaseString]];
 
   NSString *base64Head = @"data:";
   if ([request.URL.absoluteString rangeOfString:base64Head].location != NSNotFound) {
@@ -1093,7 +1096,7 @@ static NSDictionary* customCertificatesForHost;
 
   if (_onLoadingStart) {
     // We have this check to filter out iframe requests and whatnot
-    if (isTopFrame) {
+    if (isTopFrame && !isDownload) {
       NSMutableDictionary<NSString *, id> *event = [self baseEvent];
       [event addEntriesFromDictionary: @{
         @"url": (request.URL).absoluteString,


### PR DESCRIPTION
request url을 분석, 확장자가 있고 다운로드 지원 확장자일 경우
onLoadStart를 실행하지 않도록 수정