### PR TITLE
accept-type 이 이미지일 때에만 image picker 사용하도록 수정

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -309,10 +309,13 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     }
 
     Intent fileSelectionIntent = getFileChooserIntent(acceptTypes, allowMultiple);
-    Intent imagePickerIntent = getImagePickerIntent(acceptTypes, allowMultiple);
-
     Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
-    if (imagePickerIntent == null) {
+
+    // Using custom image picker when Accept-Type is `*/images` only
+    if (isSingleImageType(acceptTypes)) {
+      Intent imagePickerIntent = getImagePickerIntent(allowMultiple);
+      activity.startActivityForResult(imagePickerIntent, PICKER);
+    } else {
       chooserIntent.putExtra(Intent.EXTRA_INTENT, fileSelectionIntent);
       chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents.toArray(new Parcelable[]{}));
 
@@ -321,8 +324,6 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       } else {
         Log.w("RNCWebViewModule", "there is no Activity to handle this Intent");
       }
-    } else {
-      activity.startActivityForResult(imagePickerIntent, PICKER);
     }
 
     return true;
@@ -371,6 +372,11 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     }
 
     return needed;
+  }
+
+  private Boolean isSingleImageType(String[] acceptTypes) {
+    String acceptType = acceptTypes.length == 1 ? acceptTypes[0] : "";
+    return !acceptType.equals("") && acceptsImages(acceptType);
   }
 
   private Intent getPhotoIntent() {
@@ -428,17 +434,13 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     return intent;
   }
 
-  private Intent getImagePickerIntent(String[] acceptTypes, boolean allowMultiple) {
-    if (acceptsImages(acceptTypes)) {
-      Intent intent = new Intent(getCurrentActivity(), LocalFoldersActivity.class);
-      intent.putExtra(Extra.STYLE, IMAGE_PICKER_STYLE);
-      intent.putExtra(Extra.MAX_SIZE, IMAGE_PICKER_MAX_SIZE);
-      intent.putExtra(Extra.AVAILABLE_SIZE, IMAGE_PICKER_AVAILABLE_SIZE);
-      intent.putExtra(Extra.ALLOW_MULTIPLE, allowMultiple);
-      return intent;
-    } else {
-      return null;
-    }
+  private Intent getImagePickerIntent(boolean allowMultiple) {
+    Intent intent = new Intent(getCurrentActivity(), LocalFoldersActivity.class);
+    intent.putExtra(Extra.STYLE, IMAGE_PICKER_STYLE);
+    intent.putExtra(Extra.MAX_SIZE, IMAGE_PICKER_MAX_SIZE);
+    intent.putExtra(Extra.AVAILABLE_SIZE, IMAGE_PICKER_AVAILABLE_SIZE);
+    intent.putExtra(Extra.ALLOW_MULTIPLE, allowMultiple);
+    return intent;
   }
 
   private Boolean acceptsImages(String types) {


### PR DESCRIPTION
## Description

accept-type 이 비어있을 때(파일첨부)에도 image picker 가 노출되는 문제가
있어 activity 띄우는 조건을 수정함

### Changes

- Custom image picker 를 사용하는 조건 변경
  - Accept-Type 이 1개이고, 이미지 타입일 때
  - 위 조건을 평가하는 isSingleImageType 메서드 구현
- getImagePickerIntent 개선
  - 메서드 이름에 맞게 ImagePicker intent 만 반환하도록 구현함
  - (부수적인 로직은 별도로 분리됨)

### How to test

- 뉴클래스 > 글쓰기
  - 이미지 첨부 선택 시: Image picker 가 노출되어야 함
  - 파일 첨부 선택 시: 파일 앱이 실행되어야 함 (혹은 파일관련 앱 선택 창이 떠야함)

refs #https://github.com/classtinginc/classting-rn/issues/3418