### PR TITLE
iOS 12에서 Content-Disposition 헤더 값을 가져올 수 있도록 수정

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1150,6 +1150,11 @@ static NSDictionary* customCertificatesForHost;
       NSString *disposition = nil;
       if (@available(iOS 13, *)) {
         disposition = [response valueForHTTPHeaderField:@"Content-Disposition"];
+      } else {
+        if ([response respondsToSelector:@selector(allHeaderFields)]) {
+          NSDictionary *headerFields = [response allHeaderFields];
+          disposition = headerFields[@"Content-Disposition"];
+        }
       }
       BOOL isAttachment = disposition != nil && [disposition hasPrefix:@"attachment"];
       if (isAttachment || !navigationResponse.canShowMIMEType) {


### PR DESCRIPTION
Short description
iOS 12 기기에서 Content-Disposition 헤더 값을 설정하지 않아, 다운로드 요청 메서드가 호출되지 않는 현상을 수정하였습니다.

Proposed changes

- fix(ios): iOS 12에서 content-disposition 값을 가져올 수 있도록 수정
```
iOS 12에서 서버 응답 헤더에서 content-disposition 값을 가져오는 로직이 누락되어 파일 다운로드가
정상적으로 동작하지 않는 현상을 수정하였습니다.
```

refs [#4044](https://github.com/classtinginc/classting-rn/issues/4044)