### PR TITLE
(안드로이드) build.gradle 업데이트

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,5 +134,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.github.classtinginc:android-image-picker:1.1.3'
+  implementation 'com.github.classtinginc:android-image-picker:1.1.4'
+  implementation 'com.google.code.gson:gson:2.8.3'
 }


### PR DESCRIPTION
android-image-picker에 이미지 형식 변환 기능이 추가됨([PR](https://github.com/classtinginc/android-image-picker/pull/1))에 따라,
 build.gradle의 디펜던시를 수정하였습니다.

chore: build.gradle 업데이트

- android-image-picker 버전 1.1.4로 업데이트
- gson 디펜던시 추가

ref [4088](https://github.com/classtinginc/classting-rn/issues/4088)