### PR TITLE
안드로이드 이미지 피커 버전 업데이트

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,6 +134,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.github.classtinginc:android-image-picker:1.1.4'
+  implementation 'com.github.classtinginc:android-image-picker:1.1.5'
   implementation 'com.google.code.gson:gson:2.8.3'
 }


### PR DESCRIPTION
heic 이미지 형식 변환 로직에 exif 로테이션 유지 작업을 포함한  android-image-picker 1.1.5 버전이 반영되었습니다.

ref [4123](https://github.com/classtinginc/classting-rn/issues/4123)