### PR TITLE
getCookies 메소드 구현

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -7,6 +7,7 @@
 
 #import <React/RCTView.h>
 #import <React/RCTDefines.h>
+#import <React/RCTBridgeModule.h>
 #import <WebKit/WebKit.h>
 
 @class RNCWebView;
@@ -79,6 +80,7 @@
 - (void)goForward;
 - (void)goBack;
 - (void)reload;
+- (void)getCookies:(RCTResponseSenderBlock)callback;
 - (void)stopLoading;
 #if !TARGET_OS_OSX
 - (void)addPullToRefreshControl;

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -195,6 +195,20 @@ RCT_EXPORT_METHOD(reload:(nonnull NSNumber *)reactTag)
   }];
 }
 
+RCT_EXPORT_METHOD(getCookies:(nonnull NSNumber *)reactTag callback:(RCTResponseSenderBlock)callback)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {
+    RNCWebView *view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RNCWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RNCWebView, got: %@", view);
+    } else {
+      dispatch_async(dispatch_get_main_queue(), ^(){
+        [view getCookies:callback];
+      });
+    }
+  }];
+}
+
 RCT_EXPORT_METHOD(stopLoading:(nonnull NSNumber *)reactTag)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 // eslint-disable-next-line
-import { IOSWebViewProps, AndroidWebViewProps } from './lib/WebViewTypes';
+import { IOSWebViewProps, AndroidWebViewProps, WebViewCookies } from './lib/WebViewTypes';
 
 export { FileDownload, WebViewMessageEvent, WebViewNavigation } from "./lib/WebViewTypes";
 
@@ -21,6 +21,13 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      * Reloads the current page.
      */
     reload: () => void;
+
+    /**
+     * Get cookies from httpCookieStore(WKHTTPCookieStore).
+     * 
+     * - iOS only (android result is always null)
+     */
+    getCookies: (callback: (cookies: WebViewCookies | null) => void) => void;
 
     /**
      * Stop loading the current page.

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -31,6 +31,7 @@ import {
   NativeWebViewAndroid,
   State,
   RNCWebViewUIManagerAndroid,
+  WebViewCookies,
 } from './WebViewTypes';
 
 import styles from './WebView.styles';
@@ -116,6 +117,15 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
       undefined
     );
   };
+
+  /**
+   * Get cookies from httpCookieStore(WKHTTPCookieStore).
+   * 
+   * - iOS only (android result is always null)
+   */
+  getCookies = (callback: (cookies: WebViewCookies | null) => void) => {
+    callback(null);
+  }
 
   stopLoading = () => {
     UIManager.dispatchViewManagerCommand(

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -29,6 +29,7 @@ import {
   ViewManager,
   State,
   RNCWebViewUIManagerIOS,
+  WebViewCookies,
 } from './WebViewTypes';
 
 import styles from './WebView.styles';
@@ -108,6 +109,20 @@ class WebView extends React.Component<IOSWebViewProps, State> {
       this.getCommands().reload,
       undefined,
     );
+  };
+
+  /**
+   * Get cookies from httpCookieStore(WKHTTPCookieStore).
+   * 
+   * - iOS only (android result is always null)
+   */
+  getCookies = (callback: (cookies: WebViewCookies | null) => void) => {
+    try {
+      const reactTagId = this.getWebViewHandle();
+      RNCWebViewManager.getCookies(reactTagId, callback);
+    } catch (_) {
+      callback(null);
+    }
   };
 
   /**

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -20,7 +20,8 @@ type WebViewCommands =
   | 'postMessage'
   | 'injectJavaScript'
   | 'loadUrl'
-  | 'requestFocus';
+  | 'requestFocus'
+  | 'getCookies';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 
@@ -120,6 +121,7 @@ export interface BlobDownload {
 
 export interface FileDownload {
   downloadUrl: string;
+  disposition?: string;
 }
 
 export type DecelerationRateConstant = 'normal' | 'fast';
@@ -234,8 +236,24 @@ export interface WebViewSourceHtml {
 
 export type WebViewSource = WebViewSourceUri | WebViewSourceHtml;
 
+export interface WebViewCookie {
+  name: string;
+  value: string;
+  path?: string;
+  domain?: string;
+  version?: string;
+  expires?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+}
+
+export interface WebViewCookies {
+  [key: string]: WebViewCookie;
+}
+
 export interface ViewManager {
   startLoadWithResult: Function;
+  getCookies: (reactTagId: number, callback: (cookies: WebViewCookies | null) => void) => void;
 }
 
 export interface WebViewNativeConfig {


### PR DESCRIPTION
### Description

iOS 웹뷰 인스턴스의 data store 내에서 쿠키 값을 조회하기 위한
getCookies 메소드를 추가로 구현함

- Cookie type 정의
- getCookies 메소드 구현 (iOS)
  - Android 에서는 항상 null 반환하도록 처리
