### PR TITLE
애드팝콘 SSP 하이브리드 웹 SDK 연동

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,13 @@ buildscript {
   } else {
     repositories {
       jcenter()
+      mavenCentral()
+    }
+
+    allprojects {
+      repositories {
+        mavenCentral()
+      }
     }
 
     dependencies {
@@ -136,4 +143,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.github.classtinginc:android-image-picker:1.1.9'
   implementation 'com.google.code.gson:gson:2.8.3'
+  implementation 'com.igaworks.ssp:IgawAdPopcornSSP:3.2.0'
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -77,6 +77,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.ContentSizeChangeEvent;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.igaworks.ssp.part.hybrid.AdPopcornSSPJsBridge;
 import com.reactnativecommunity.webview.RNCWebViewModule.ShouldOverrideUrlLoadingLock.ShouldOverrideCallbackState;
 import com.reactnativecommunity.webview.events.TopLoadingErrorEvent;
 import com.reactnativecommunity.webview.events.TopHttpErrorEvent;
@@ -223,6 +224,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
 
     webView.addJavascriptInterface(new JavaScriptInterface(webView.getContext(), reactContext), "Android");
+    webView.addJavascriptInterface(new AdPopcornSSPJsBridge(webView.getContext(), webView), AdPopcornSSPJsBridge.INTERFACE_NAME);
 
     webView.setDownloadListener(new DownloadListener() {
       private String DOWNLOAD_SUB_DIR = "/Classting";

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -24,6 +24,7 @@ static NSTimer *keyboardTimer;
 static NSString *const HistoryShimName = @"ReactNativeHistoryShim";
 static NSString *const IOSFunc = @"IOSFunc";
 static NSString *const MessageHandlerName = @"ReactNativeWebView";
+static NSString *const AdpopcornSSP = @"apssp";
 static NSURLCredential* clientAuthenticationCredential;
 static NSDictionary* customCertificatesForHost;
 static inline BOOL isEmpty(id value)
@@ -252,7 +253,10 @@ static inline BOOL isEmpty(id value)
 
   [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
                                                             name:IOSFunc];
-
+    
+  [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                            name:AdpopcornSSP];
+  
   [self resetupScripts:wkWebViewConfig];
 
 #if !TARGET_OS_OSX
@@ -983,6 +987,21 @@ static inline BOOL isEmpty(id value)
   BOOL isDownload = [allowFileExtensions containsObject:[fileExtension lowercaseString]];
 
   NSString *base64Head = @"data:";
+    
+  NSString *requestString = navigationAction.request.URL.absoluteString;
+
+  if(navigationType == UIWebViewNavigationTypeLinkClicked)
+  {
+      decisionHandler(WKNavigationActionPolicyCancel);
+      NSURL *requestURL = [NSURL URLWithString:requestString];
+      if(@available(iOS 10, *))
+      {
+          [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:^(BOOL success) {
+          }];
+      }
+      return;
+  }
+    
   if ([request.URL.absoluteString rangeOfString:base64Head].location != NSNotFound) {
     @try {
       NSString *base64String = request.URL.absoluteString;


### PR DESCRIPTION
웹뷰에 애드팝콘 SSP 광고를 노출하기 위해, 애드팝콘 SSP
하이브리드 웹 SDK 연동 가이드에 따라 SDK를 연동하였습니다.

참고 : [애드팝콘 하이브리드 웹 SDK 연동 가이드](https://adpopcorn.notion.site/SSP-WEB-SDK-a10d7168f12d4efb85395b384bfc4843)