### PR TITLE
파일 다운로드 링크가 외부브라우저에서 실행되지 않도록 함

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -995,7 +995,8 @@ static inline BOOL isEmpty(id value)
     
   NSString *requestString = navigationAction.request.URL.absoluteString;
 
-  if(navigationType == UIWebViewNavigationTypeLinkClicked)
+  // 애드팝콘 웹뷰 광고를 외부브라우저로 열기위함. 다만 파일 다운로드인 경우 해당 로직을 타지 않도록 함
+  if(!isDownload && navigationType == UIWebViewNavigationTypeLinkClicked)
   {
       decisionHandler(WKNavigationActionPolicyCancel);
       NSURL *requestURL = [NSURL URLWithString:requestString];


### PR DESCRIPTION
애드팝콘 SSP 연동 중, 클래스팅 웹뷰에 첨부된 파일 다운로드 anchor 태그가
외부브라우저로 열리는 이슈 발생.

파일 다운로드 요청인 경우, 외부브라우저를 여는 로직이 실행되지 않도록 함