### PR TITLE
광고를 외부브라우저로 열기위한 코드 제거

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -992,22 +992,6 @@ static inline BOOL isEmpty(id value)
   BOOL isDownload = [allowFileExtensions containsObject:[fileExtension lowercaseString]];
 
   NSString *base64Head = @"data:";
-    
-  NSString *requestString = navigationAction.request.URL.absoluteString;
-
-  // 애드팝콘 웹뷰 광고를 외부브라우저로 열기위함. 다만 파일 다운로드인 경우 해당 로직을 타지 않도록 함
-  if(!isDownload && navigationType == UIWebViewNavigationTypeLinkClicked)
-  {
-      decisionHandler(WKNavigationActionPolicyCancel);
-      NSURL *requestURL = [NSURL URLWithString:requestString];
-      if(@available(iOS 10, *))
-      {
-          [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:^(BOOL success) {
-          }];
-      }
-      return;
-  }
-    
   if ([request.URL.absoluteString rangeOfString:base64Head].location != NSNotFound) {
     @try {
       NSString *base64String = request.URL.absoluteString;


### PR DESCRIPTION
클래스팅 웹뷰에 첨부된 파일 링크 클릭 시, 외부브라우저를 오픈하지 않도록 수정하였으나
파일 확장자가 포함되지 않은 <a href=""/> 형태의 태그 클릭 시 외부브라우저로 의도하지 않게 링크가 연결되는 현상이 발생

광고를 외부브라우저로 연결하는 코드를 제거하고, 웹 페이지에서 광고 클릭 핸들러를 커스텀하여 사용하는 방법을 적용하는 것으로 함